### PR TITLE
Add transfer history tracking and persistent globe overlays

### DIFF
--- a/src/components/CountryMarkers.tsx
+++ b/src/components/CountryMarkers.tsx
@@ -11,17 +11,21 @@ interface CountryMarker {
 interface CountryMarkersProps {
   markers: CountryMarker[];
   activeCountries?: string[];
+  transferCounts?: Record<string, number>;
 }
 
-const CountryMarkers: React.FC<CountryMarkersProps> = ({ 
-  markers, 
-  activeCountries = [] 
+const CountryMarkers: React.FC<CountryMarkersProps> = ({
+  markers,
+  activeCountries = [],
+  transferCounts = {}
 }) => {
   return (
     <group>
       {markers.map((marker) => {
         const isActive = activeCountries.includes(marker.code);
-        
+        const transferCount = transferCounts[marker.code] ?? 0;
+        const badgeWidth = Math.max(0.3, 0.24 + transferCount.toString().length * 0.08);
+
         return (
           <group key={marker.code}>
             {/* Country dot */}
@@ -56,6 +60,30 @@ const CountryMarkers: React.FC<CountryMarkersProps> = ({
                   opacity={0.3}
                 />
               </mesh>
+            )}
+
+            {/* Transfer count badge */}
+            {transferCount > 0 && (
+              <group position={[marker.position[0], marker.position[1] + 0.4, marker.position[2]]}>
+                <mesh>
+                  <planeGeometry args={[badgeWidth, 0.22]} />
+                  <meshBasicMaterial
+                    color={isActive ? '#2563eb' : '#0f172a'}
+                    transparent
+                    opacity={isActive ? 0.95 : 0.7}
+                  />
+                </mesh>
+                <Text
+                  position={[0, 0, 0.01]}
+                  fontSize={0.12}
+                  color="#ffffff"
+                  anchorX="center"
+                  anchorY="middle"
+                  fontWeight="bold"
+                >
+                  {transferCount}
+                </Text>
+              </group>
             )}
           </group>
         );

--- a/src/components/Globe3D.tsx
+++ b/src/components/Globe3D.tsx
@@ -8,12 +8,14 @@ interface Globe3DProps {
   autoRotate?: boolean;
   rotationSpeed?: number;
   activeCountries?: string[];
+  transferCounts?: Record<string, number>;
 }
 
-const Globe3D: React.FC<Globe3DProps> = ({ 
-  autoRotate = true, 
+const Globe3D: React.FC<Globe3DProps> = ({
+  autoRotate = true,
   rotationSpeed = 0.005,
-  activeCountries = []
+  activeCountries = [],
+  transferCounts = {}
 }) => {
   const globeRef = useRef<Mesh>(null);
 
@@ -83,9 +85,10 @@ const Globe3D: React.FC<Globe3DProps> = ({
       </mesh>
       
       {/* Country Markers */}
-      <CountryMarkers 
+      <CountryMarkers
         markers={countryMarkers}
         activeCountries={activeCountries}
+        transferCounts={transferCounts}
       />
       
       {/* Lighting */}

--- a/src/components/TransferAnimation.tsx
+++ b/src/components/TransferAnimation.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect, Suspense } from 'react';
+import React, { useState, useEffect, Suspense, useMemo } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls, PerspectiveCamera } from '@react-three/drei';
 import Globe3D from './Globe3D';
 import TransferArc from './TransferArc';
+import type { TransferHistoryEntry } from '../types/transfers';
 
 // Error boundary component for 3D content
 class ThreeErrorBoundary extends React.Component<
@@ -41,7 +42,7 @@ const LoadingFallback = () => (
   </div>
 );
 
-// Error fallback component  
+// Error fallback component
 const ErrorFallback = () => (
   <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-background to-card">
     <div className="text-center space-y-4">
@@ -64,61 +65,149 @@ interface TransferPoint {
 }
 
 interface TransferAnimationProps {
-  isActive: boolean;
-  fromCountry: string;
-  toCountry: string;
-  amount: number;
-  fromCurrency: string;
-  toCurrency: string;
+  transferHistory: TransferHistoryEntry[];
 }
 
-const TransferAnimation: React.FC<TransferAnimationProps> = ({
-  isActive,
-  fromCountry,
-  toCountry,
-  amount,
-  fromCurrency,
-  toCurrency,
-}) => {
+const TransferAnimation: React.FC<TransferAnimationProps> = ({ transferHistory }) => {
   const [animationStep, setAnimationStep] = useState(0);
 
-  // 3D positions for countries on the globe (radius = 2)
-  const transferPoints: Record<string, TransferPoint> = {
-    UK: { id: 'uk', position: [0.5, 1.2, 1.5], country: 'United Kingdom', currency: 'GBP' },
-    US: { id: 'us', position: [-1.5, 0.8, 1.2], country: 'United States', currency: 'USD' },
-    IN: { id: 'in', position: [1.2, 0.5, -1.5], country: 'India', currency: 'INR' },
-    CA: { id: 'ca', position: [-1.8, 1.0, 0.8], country: 'Canada', currency: 'CAD' },
-    AU: { id: 'au', position: [1.5, -1.2, 1.0], country: 'Australia', currency: 'AUD' },
-    DE: { id: 'de', position: [0.8, 1.0, 1.7], country: 'Germany', currency: 'EUR' },
-    FR: { id: 'fr', position: [0.3, 1.1, 1.8], country: 'France', currency: 'EUR' },
-    JP: { id: 'jp', position: [1.8, 0.8, -0.5], country: 'Japan', currency: 'JPY' },
-    SG: { id: 'sg', position: [1.4, -0.3, -1.4], country: 'Singapore', currency: 'SGD' },
-    AE: { id: 'ae', position: [1.0, 0.2, -1.8], country: 'UAE', currency: 'AED' },
-  };
+  const transferPoints = useMemo<Record<string, TransferPoint>>(
+    () => ({
+      UK: { id: 'uk', position: [0.5, 1.2, 1.5], country: 'United Kingdom', currency: 'GBP' },
+      US: { id: 'us', position: [-1.5, 0.8, 1.2], country: 'United States', currency: 'USD' },
+      IN: { id: 'in', position: [1.2, 0.5, -1.5], country: 'India', currency: 'INR' },
+      CA: { id: 'ca', position: [-1.8, 1.0, 0.8], country: 'Canada', currency: 'CAD' },
+      AU: { id: 'au', position: [1.5, -1.2, 1.0], country: 'Australia', currency: 'AUD' },
+      DE: { id: 'de', position: [0.8, 1.0, 1.7], country: 'Germany', currency: 'EUR' },
+      FR: { id: 'fr', position: [0.3, 1.1, 1.8], country: 'France', currency: 'EUR' },
+      JP: { id: 'jp', position: [1.8, 0.8, -0.5], country: 'Japan', currency: 'JPY' },
+      SG: { id: 'sg', position: [1.4, -0.3, -1.4], country: 'Singapore', currency: 'SGD' },
+      AE: { id: 'ae', position: [1.0, 0.2, -1.8], country: 'UAE', currency: 'AED' },
+    }),
+    [],
+  );
+
+  const activeTransfer = useMemo(
+    () => transferHistory.find((transfer) => transfer.status === 'active') ?? null,
+    [transferHistory],
+  );
+  const pendingTransfer = useMemo(
+    () => transferHistory.find((transfer) => transfer.status === 'pending') ?? null,
+    [transferHistory],
+  );
+  const currentTransfer = activeTransfer ?? pendingTransfer ?? null;
 
   useEffect(() => {
-    if (isActive) {
+    if (currentTransfer) {
       setAnimationStep(0);
       const timer1 = setTimeout(() => setAnimationStep(1), 500);
       const timer2 = setTimeout(() => setAnimationStep(2), 1500);
       const timer3 = setTimeout(() => setAnimationStep(3), 3000);
-      
+
       return () => {
         clearTimeout(timer1);
         clearTimeout(timer2);
         clearTimeout(timer3);
       };
-    } else {
-      setAnimationStep(0);
     }
-  }, [isActive]);
 
-  const fromPoint = transferPoints[fromCountry];
-  const toPoint = transferPoints[toCountry];
+    setAnimationStep(0);
+    return undefined;
+  }, [currentTransfer?.id]);
 
-  if (!fromPoint || !toPoint) {
+  const activeCountries = useMemo(() => {
+    const highlighted = new Set<string>();
+    transferHistory.forEach((transfer) => {
+      if (transfer.status === 'active' || transfer.status === 'pending') {
+        highlighted.add(transfer.fromCountry);
+        highlighted.add(transfer.toCountry);
+      }
+    });
+    return Array.from(highlighted);
+  }, [transferHistory]);
+
+  const transferCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    transferHistory.forEach((transfer) => {
+      counts[transfer.fromCountry] = (counts[transfer.fromCountry] || 0) + 1;
+      counts[transfer.toCountry] = (counts[transfer.toCountry] || 0) + 1;
+    });
+    return counts;
+  }, [transferHistory]);
+
+  if (currentTransfer) {
+    const fromPoint = transferPoints[currentTransfer.fromCountry];
+    const toPoint = transferPoints[currentTransfer.toCountry];
+
+    if (!fromPoint || !toPoint) {
+      return <ErrorFallback />;
+    }
+  }
+
+  const sortedHistory = useMemo(() => {
+    const statusPriority: Record<TransferHistoryEntry['status'], number> = {
+      completed: 0,
+      pending: 1,
+      active: 2,
+    };
+
+    return [...transferHistory].sort((a, b) => statusPriority[a.status] - statusPriority[b.status]);
+  }, [transferHistory]);
+
+  const arcs = useMemo(
+    () =>
+      sortedHistory
+        .map((transfer) => {
+          const fromPoint = transferPoints[transfer.fromCountry];
+          const toPoint = transferPoints[transfer.toCountry];
+
+          if (!fromPoint || !toPoint) {
+            return null;
+          }
+
+          const arcColor =
+            transfer.status === 'completed'
+              ? '#22c55e'
+              : transfer.status === 'pending'
+              ? '#f59e0b'
+              : '#3b82f6';
+
+          return (
+            <TransferArc
+              key={transfer.id}
+              startPoint={fromPoint.position}
+              endPoint={toPoint.position}
+              status={transfer.status}
+              color={arcColor}
+              currency={transfer.toCurrency}
+              amount={Math.round(transfer.amount * 1.2)}
+            />
+          );
+        })
+        .filter((arc): arc is JSX.Element => arc !== null),
+    [sortedHistory, transferPoints],
+  );
+
+  const latestTransfer = transferHistory[transferHistory.length - 1] ?? null;
+  const displayedTransfer = currentTransfer ?? latestTransfer;
+
+  if (!displayedTransfer && arcs.length === 0) {
     return <ErrorFallback />;
   }
+
+  const isAnimating = Boolean(currentTransfer);
+
+  const statusAccent: Record<TransferHistoryEntry['status'], string> = {
+    pending: 'text-amber-300',
+    active: 'text-sky-300',
+    completed: 'text-emerald-400',
+  };
+
+  const statusLabel: Record<TransferHistoryEntry['status'], string> = {
+    pending: 'Pending',
+    active: 'In progress',
+    completed: 'Completed',
+  };
 
   return (
     <div className="relative w-full h-full bg-gradient-to-br from-background to-card">
@@ -126,26 +215,18 @@ const TransferAnimation: React.FC<TransferAnimationProps> = ({
         <Suspense fallback={<LoadingFallback />}>
           <Canvas className="w-full h-full">
             <PerspectiveCamera makeDefault position={[0, 0, 8]} fov={50} />
-            
+
             {/* Globe */}
-            <Globe3D 
-              autoRotate={!isActive} 
+            <Globe3D
+              autoRotate={!isAnimating}
               rotationSpeed={0.003}
-              activeCountries={isActive ? [fromCountry, toCountry] : []}
+              activeCountries={activeCountries}
+              transferCounts={transferCounts}
             />
-            
-            {/* Transfer Arc */}
-            {isActive && (
-              <TransferArc
-                startPoint={fromPoint.position}
-                endPoint={toPoint.position}
-                isActive={animationStep >= 1}
-                color="#3b82f6"
-                currency={toCurrency}
-                amount={Math.round(amount * 1.2)}
-              />
-            )}
-            
+
+            {/* Transfer Arcs */}
+            {arcs}
+
             {/* Camera controls */}
             <OrbitControls
               enablePan={false}
@@ -154,15 +235,15 @@ const TransferAnimation: React.FC<TransferAnimationProps> = ({
               maxDistance={15}
               minPolarAngle={Math.PI / 6}
               maxPolarAngle={Math.PI - Math.PI / 6}
-              autoRotate={!isActive}
+              autoRotate={!isAnimating}
               autoRotateSpeed={0.5}
             />
           </Canvas>
         </Suspense>
       </ThreeErrorBoundary>
-      
+
       {/* Transfer status overlay */}
-      {isActive && (
+      {currentTransfer && (
         <div className="absolute top-4 right-4 space-y-2 z-10">
           <div className={`px-4 py-2 rounded-lg bg-card/90 backdrop-blur-sm border text-sm transition-all duration-500 ${
             animationStep >= 1 ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-4'
@@ -172,7 +253,7 @@ const TransferAnimation: React.FC<TransferAnimationProps> = ({
               Initiating transfer...
             </div>
           </div>
-          
+
           {animationStep >= 2 && (
             <div className="px-4 py-2 rounded-lg bg-card/90 backdrop-blur-sm border text-sm animate-slide-in-up">
               <div className="flex items-center gap-2">
@@ -181,7 +262,7 @@ const TransferAnimation: React.FC<TransferAnimationProps> = ({
               </div>
             </div>
           )}
-          
+
           {animationStep >= 3 && (
             <div className="px-4 py-2 rounded-lg bg-accent/20 backdrop-blur-sm border-accent text-accent-foreground text-sm animate-slide-in-up">
               <div className="flex items-center gap-2">
@@ -190,6 +271,25 @@ const TransferAnimation: React.FC<TransferAnimationProps> = ({
               </div>
             </div>
           )}
+        </div>
+      )}
+
+      {/* Latest transfer summary */}
+      {displayedTransfer && (
+        <div className="absolute bottom-4 right-4 bg-card/80 backdrop-blur-sm border border-border/50 rounded-xl px-4 py-3 text-xs text-muted-foreground max-w-xs space-y-2 shadow-lg">
+          <div className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground/70">
+            Latest transfer
+          </div>
+          <div className="text-sm font-semibold text-foreground">
+            {displayedTransfer.fromCountry} → {displayedTransfer.toCountry}
+          </div>
+          <div className="text-xs text-muted-foreground">
+            {displayedTransfer.fromCurrency} {displayedTransfer.amount.toLocaleString()} →{' '}
+            {displayedTransfer.toCurrency} {Math.round(displayedTransfer.amount * 1.2).toLocaleString()}
+          </div>
+          <div className={`text-xs font-semibold ${statusAccent[displayedTransfer.status]}`}>
+            {statusLabel[displayedTransfer.status]}
+          </div>
         </div>
       )}
 

--- a/src/types/transfers.ts
+++ b/src/types/transfers.ts
@@ -1,0 +1,14 @@
+export type TransferStatus = 'pending' | 'active' | 'completed';
+
+export interface TransferHistoryEntry {
+  id: string;
+  fromCountry: string;
+  toCountry: string;
+  amount: number;
+  fromCurrency: string;
+  toCurrency: string;
+  status: TransferStatus;
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+}


### PR DESCRIPTION
## Summary
- track full transfer history with lifecycle transitions in the money transfer app and surface it to the animation layer
- render active and completed transfer arcs while surfacing per-country activity badges on the globe
- share transfer history types for reuse across components

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d89b6e764483249935f27fab741b19