### PR TITLE
fix: update map view state typing

### DIFF
--- a/src/components/MoneyTransferApp.tsx
+++ b/src/components/MoneyTransferApp.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Layer, Map, Marker, Source } from 'react-map-gl/maplibre';
-import type { MapViewState } from 'react-map-gl/maplibre';
+import type { ViewState } from 'react-map-gl/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
 import type { TransferHistoryEntry } from '../types/transfers';
@@ -101,6 +101,8 @@ const formatRelativeTime = (timestamp: number) => {
   const daysAgo = Math.round(hoursAgo / 24);
   return `${daysAgo} day${daysAgo > 1 ? 's' : ''} ago`;
 };
+
+type MapViewState = ViewState & { width: number; height: number };
 
 const defaultViewState: MapViewState = {
   longitude: 0,


### PR DESCRIPTION
## Summary
- import the ViewState type from react-map-gl/maplibre and define a local MapViewState alias
- ensure default and controlled map view state include required width and height properties

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8ca0869a08324a7af5b4ddce46738